### PR TITLE
Sort future events in chronological order

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,7 +9,7 @@ class EventsController < ApplicationController
   end
 
   def index
-    @future_events = Event.select { |event| event.date.future? }
+    @future_events = Event.select { |event| event.date.future? }.sort_by &:date
     @past_events = Event.select { |event| event.date.past? }.last(5)
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?
Noticed that events were sorted in the order they were created, not the time of the event.

Soonest events should be shown first.

### How are you accomplishing it?

`sort_by` method

### Is there anything reviewers should know?

Nope!


- [x] Is it safe to rollback this change if anything goes wrong?
