### PR TITLE
Added Maps autocomplete for location, get URL from address

### DIFF
--- a/app/assets/javascripts/maps_autocomplete.js
+++ b/app/assets/javascripts/maps_autocomplete.js
@@ -1,0 +1,15 @@
+var input = document.getElementById('autocomplete');
+var uwindsorBounds = new google.maps.LatLngBounds(
+  new google.maps.LatLng(42.3045, -83.0661));
+var options = {
+  bounds: uwindsorBounds
+};
+var autocomplete = new google.maps.places.Autocomplete(input, options);
+google.maps.event.addListener(autocomplete, 'place_changed', function(){
+   var place = autocomplete.getPlace();
+})
+$("form").on("keypress", function (e) {
+  if (e.keyCode == 13) {
+      return false;
+  }
+});

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -66,6 +66,6 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:title, :description, :capacity, :date, :location, :location_url)
+    params.require(:event).permit(:title, :description, :capacity, :date, :location)
   end
 end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -48,15 +48,7 @@
           <div class="input-field col s12">
             <i class="material-icons prefix">location_on</i>
             <% form.label :location %><br>
-            <%= form.text_field :location %>
-          </div>
-        </div>
-        <!--LOCATION URL-->
-        <div class="row">
-          <div class="input-field col s12">
-            <i class="material-icons prefix">insert_link</i>
-            <%= form.label "Location URL" %><br>
-            <%= form.text_field :location_url %>
+            <%= form.text_field :location, id: 'autocomplete' %>
           </div>
         </div>
         <!--DATE-->
@@ -77,3 +69,22 @@
     </div>
   </div>
 <% end %>
+
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&libraries=places"></script>
+<script>
+  var input = document.getElementById('autocomplete');
+  var uwindsorBounds = new google.maps.LatLngBounds(
+    new google.maps.LatLng(42.3045, -83.0661));
+  var options = {
+    bounds: uwindsorBounds
+  };
+  var autocomplete = new google.maps.places.Autocomplete(input, options);
+  google.maps.event.addListener(autocomplete, 'place_changed', function(){
+     var place = autocomplete.getPlace();
+  })
+  $("form").on("keypress", function (e) {
+    if (e.keyCode == 13) {
+        return false;
+    }
+});
+</script>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,11 +6,7 @@
     <p style="text-align:left;"><b>Date: </b><%= @event.date.strftime('%B %d, %Y at %l:%M %p') %><p>
     <p style="text-align:left;">
       <b>Location: </b>
-      <% if @event.location_url&.present? %>
-        <%= link_to @event.location, @event.location_url, target: :_blank %>
-      <% else %>
-        <%= @event.location %>
-      <% end %>
+      <%= link_to @event.location, "https://maps.google.com/?q=#{@event.location}", target: :_blank %>
     <p>
     <p>
       <% if current_user && @event.date.future? %>

--- a/db/migrate/20190401000626_drop_location_url_from_events.rb
+++ b/db/migrate/20190401000626_drop_location_url_from_events.rb
@@ -1,0 +1,5 @@
+class DropLocationUrlFromEvents < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :events, :location_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190301065139) do
+ActiveRecord::Schema.define(version: 20190401000626) do
 
   create_table "events", force: :cascade do |t|
     t.string "title"
@@ -18,7 +18,6 @@ ActiveRecord::Schema.define(version: 20190301065139) do
     t.string "location"
     t.integer "capacity"
     t.datetime "date"
-    t.string "location_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1490434/55297423-bf5c8b80-53da-11e9-82cb-679e4cf67e38.png)


### What are you trying to accomplish?

Added Maps autocomplete suggestions for event locations.

The API bias is set to the Windsor area, so Maps will return results in the Windsor area first.

Instead of manually setting a Maps/location URL in another field in the form, the URL will automatically be generated from the location address field.

### How are you accomplishing it?

Using Maps API/javascript.

### Is there anything reviewers should know?

Javascript should be separated in a separate file eventually. 

- [x] Is it safe to rollback this change if anything goes wrong?
