### PR TITLE
Added markdown rendering capability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,6 @@ gem "fuzzy-string-match"
 gem 'rubysl-securerandom'
 gem 'bootstrap'
 gem 'pry-byebug'
+
+# Markdown rendering
+gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,7 @@ GEM
       ffi (~> 1.0)
     rbnacl (3.4.0)
       ffi
+    redcarpet (3.4.0)
     rest-client (2.1.0.rc1)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -279,7 +280,6 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
-  actionview (>= 5.1.6.2)
   bootstrap
   byebug
   capybara (~> 2.13)
@@ -295,6 +295,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.7)
   rails (~> 5.1.6, >= 5.1.6.1)
+  redcarpet
   rubysl-securerandom
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,22 @@
 module ApplicationHelper
+  def markdown(text)
+    options = {
+      filter_html:     true,
+      hard_wrap:       true,
+      link_attributes: { rel: 'nofollow', target: "_blank" },
+      space_after_headers: true,
+      fenced_code_blocks: true
+    }
+
+    extensions = {
+      autolink:           true,
+      superscript:        true,
+      disable_indented_code_blocks: true
+    }
+
+    renderer = Redcarpet::Render::HTML.new(options)
+    markdown = Redcarpet::Markdown.new(renderer, extensions)
+
+    markdown.render(text).html_safe
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Adding markdown functionality. We will work on making most static pages modifiable using markdown, so non-devs and future CSS members can easily edit pages without actually modifying the code.

### How are you accomplishing it?

- Used the RedCarpet markdown rendering gem
- Added a `markdown(text)` helper method (can be used anywhere) that will return rendered HTML of the markdown text

### Is there anything reviewers should know?

Nope



- [x] Is it safe to rollback this change if anything goes wrong?
