### PR TITLE
Added resources markdown page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,7 @@
 class PagesController < ApplicationController
   def discord
   end
+
+  def resources
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,15 +3,17 @@ module ApplicationHelper
     options = {
       filter_html:     true,
       hard_wrap:       true,
-      link_attributes: { rel: 'nofollow', target: "_blank" },
       space_after_headers: true,
-      fenced_code_blocks: true
+      fenced_code_blocks: true,
+      with_toc_data:   true
     }
 
     extensions = {
       autolink:           true,
       superscript:        true,
-      disable_indented_code_blocks: true
+      disable_indented_code_blocks: true,
+      tables:             true
+
     }
 
     renderer = Redcarpet::Render::HTML.new(options)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,10 @@
               <%= link_to "Discord", :discord_path %>
             </li>
             <li>
-              <a href="http://tutor.cs.uwindsor.ca/" target="_blank"">Tutoring</a>
+              <a href="http://tutor.cs.uwindsor.ca/" target="_blank">Tutoring</a>
+            </li>
+            <li>
+              <%= link_to "Resources", :resources %>
             </li>
             <li>
               <a href="https://github.com/EricPickup/uwindsor-css-events-site" target="_blank">Contribute</a>
@@ -84,6 +87,9 @@
         </li>
         <li>
           <a href="http://tutor.cs.uwindsor.ca/" target="_blank"">Tutoring</a>
+        </li>
+        <li>
+          <%= link_to "Resources", :resources %>
         </li>
         <li>
           <a href="https://github.com/EricPickup/uwindsor-css-events-site" target="_blank">Contribute</a>

--- a/app/views/pages/RESOURCES.markdown
+++ b/app/views/pages/RESOURCES.markdown
@@ -1,0 +1,40 @@
+Table of Contents
+-----------------
+
+- [Introduction](#introduction)
+- [Courses](#courses)
+- [Co-op/Internships](#co-op-and-internships)
+- [Miscellaneous](#miscellaneous)
+
+# Introduction
+------------
+
+
+This is an open-source resources file for students at the University of Windsor.
+
+Anyone can contribute to this document (submissions require approval) through GitHub.
+
+### Contributors
+
+- [Eric Pickup](http://pickuperic.com)
+
+
+# Courses
+------------
+
+
+Add typical course offerings, advice on specific courses.
+
+
+# Co-op and Internships
+------------
+
+
+Internship postings, specific company reviews/processes, etc.
+
+
+# Miscellaneous
+------------
+
+
+All other info

--- a/app/views/pages/resources.html.erb
+++ b/app/views/pages/resources.html.erb
@@ -1,0 +1,1 @@
+<%= markdown(File.read("app/views/pages/RESOURCES.markdown")) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,6 @@ Rails.application.routes.draw do
   resources :registration
 
   get '/discord', to: 'pages#discord', :as => 'discord_path'
+  get '/resources', to: 'pages#resources', :as => 'resources'
   get '/discord/verifications/:id', to: 'verifications#show'
 end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1490434/57044770-a47b7200-6c39-11e9-8563-148cd06c69f3.png)


### What are you trying to accomplish?

Create a crowd-sourced resource page which any student can contribute to. Will aggregate information over time and work as a valuable resource to students.

Contributors will be able to easily use GitHub's built-in "edit" feature on the markdown file and preview their changes all within GitHub. No coding or GitHub skills will be necessary to contribute to this.

### How are you accomplishing it?

Using the markdown rendering feature I added in last PR, load the markdown file and render.

### Is there anything reviewers should know?

Rendered layout looks bad because of our current CSS set-up, will be fixed when we re-do CSS


- [x] Is it safe to rollback this change if anything goes wrong?
