### PR TITLE
Added markdown support for event descriptions

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -21,7 +21,9 @@
 
         <!--DESCRIPTION-->
       <div class="form-group">
-        <%= form.label :description %><br>
+        <%= form.label :description do
+          "Description (supports #{link_to('markdown', 'https://www.markdownguide.org/basic-syntax/', target: "_blank")})".html_safe
+          end %>
         <%= form.text_area :description, class: "form-control" %>
       </div>
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -14,7 +14,7 @@
         <%= event.date.strftime('%B %d, %Y') %>
         (in <%= distance_of_time_in_words(Time.now, event.date) %>)
       </h6>
-      <p class="card-text"><%= event.description %></p>
+      <p class="card-text"><%= markdown(event.description) %></p>
       <%= link_to 'View', event_path(event), class: "card-link btn btn-primary" %>
       <% if current_user&.is_admin? %>
         <%= link_to 'Edit', edit_event_path(event), class: "card-link btn btn-warning" %>
@@ -38,7 +38,7 @@
         <%= event.date.strftime('%B %d, %Y') %>
         (<%= distance_of_time_in_words(Time.now, event.date) %> ago)
       </h6>
-      <p class="card-text"><%= event.description %></p>
+      <p class="card-text"><%= markdown(event.description) %></p>
       <%= link_to 'View', event_path(event), class: "card-link btn btn-primary" %>
       <% if current_user&.is_admin? %>
         <%= link_to 'Edit', edit_event_path(event), class: "card-link btn btn-warning" %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -12,7 +12,7 @@
     <br>
     <div class="card-text">
       <p><b>Location: </b><%= link_to @event.location, "https://maps.google.com/?q=#{@event.location}", target: :_blank %></p>
-      <p><b>Description: </b><%= @event.description %></p>
+      <p><b>Description: </b><%= markdown(@event.description) %></p>
     </div>
 
     <br>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1490434/57096147-89187180-6ce2-11e9-882f-288248c50411.png)

### What are you trying to accomplish?

Support markdown text in event descriptions. This will be helpful for events that have specific requirements (i.e. waiver links to add, rules, etc..).

### How are you accomplishing it?

Simply render the text as markdown using our markdown helper.

### Is there anything reviewers should know?

Nope!


- [x] Is it safe to rollback this change if anything goes wrong?
