### PR TITLE
Optional registration functionality

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -59,13 +59,13 @@ class EventsController < ApplicationController
   def show
     @event = Event.find(params[:id])
     if current_user
-      @registration = @event.registrations.find_by(user_id: current_user.id)
+      @user_registration = @event.registrations.find_by(user_id: current_user.id)
     end
   end
 
   private
 
   def event_params
-    params.require(:event).permit(:title, :description, :capacity, :date, :location)
+    params.require(:event).permit(:title, :description, :capacity, :date, :location, :registration_enabled)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,7 @@ class Event < ApplicationRecord
   has_many :guests, through: :registrations
 
   validates :title, :description, :location, :date, presence: true, length: { minimum: 3 }
-  validates :capacity, presence: true
+  validates :capacity, presence: true, numericality: { only_integer: true, greater_than: 0 }, if: :registration_enabled
 
   def current_capacity
     self.users.size + self.guests.size

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -27,21 +27,42 @@
         <%= form.text_area :description, class: "form-control" %>
       </div>
 
+      <!--REGISTRATION TOGGLE-->
+      <div class="form-check" style="margin-bottom:8px;">
+        <%= form.check_box :registration_enabled, id: "registration_checkbox", class: "form-check-input" %>
+        <%= form.label :registration_enabled, "Registration Enabled", for: "registration_checkbox", class: "form-check-label" %><br>
+      </div>
+
       <!--CAPACITY-->
-      <div class="form-group">
+      <div id="capacity" class="form-group" style="display:none;">
         <%= form.label :capacity %><br>
         <%= form.text_field :capacity, class: "form-control" %>
       </div>
 
+      <script type="text/javascript">
+        var checkbox = document.getElementById('registration_checkbox');
+        var capacity_div = document.getElementById('capacity');
+        checkbox.onchange = function() {show_capacity()};
+        $(document).on('page:change', show_capacity());
+        function show_capacity() {
+          console.log("test");
+          if(checkbox.checked) {
+            capacity_div.style['display'] = 'block';
+          } else {
+            capacity_div.style['display'] = 'none';
+          }
+        }
+      </script>
+
       <!--LOCATION-->
       <div class="form-group">
-        <% form.label :location %><br>
+        <%= form.label :location, "Location" %><br>
         <%= form.text_field :location, class: "form-control" %>
       </div>
 
       <!--DATE-->
       <div class="form-group">
-        <% form.label :date %><br>
+        <%= form.label :date %><br>
         <%= form.datetime_select :date, {ampm: true}, html_options = { class: "form-control" } %>
       </div>
 

--- a/app/views/events/guests.html.erb
+++ b/app/views/events/guests.html.erb
@@ -1,6 +1,6 @@
 <ol class="list-group">
   <% @event.all_guests.each do |guest| %>
-    <li class="list-group-item"><%= guest.name %> - <%= guest.email %></li>
+    <li class="list-group-item" style="display: list-item;"><%= guest.name %> - <%= guest.email %></li>
   <% end %>
 </ol>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -5,10 +5,12 @@
       <%= @event.date.strftime('%B %d, %Y') %>
       (in <%= distance_of_time_in_words(Time.now, @event.date) %>)
     </h6>
-    <br>
-    <h6 class="card-subtitle mb-2 text-muted">
-      There are <%= "#{@event.current_capacity}/#{@event.capacity}" %> spots open.
-    </h6>
+    <% if @event.registration_enabled %>
+      <br>
+      <h6 class="card-subtitle mb-2 text-muted">
+        There are <%= "#{@event.spots_remaining}/#{@event.capacity}" %> spots open.
+      </h6>
+    <% end %>
     <br>
     <div class="card-text">
       <p><b>Location: </b><%= link_to @event.location, "https://maps.google.com/?q=#{@event.location}", target: :_blank %></p>
@@ -16,24 +18,28 @@
     </div>
 
     <br>
-    <% if current_user && @event.date.future? %>
-        <% if @registration %>
-          <%= link_to 'Unregister from Event',
-            registration_path(event_id: @event.id, registration_id: @registration),
-            method: :delete,
-            class: "btn btn-danger" %>
-        <% elsif @event.current_capacity < @event.capacity %>
-          <%= link_to 'Register for Event',
-            new_registration_path(event_id: @event.id, user_id: current_user.id),
-            class: "btn btn-success" %>
-        <% else %>
-          <a class="btn btn-danger disabled">Event Full</a>
-        <% end %>
-    <% elsif current_user.nil? %>
-       <a class="btn btn-success disabled">Sign in to Register</a>
+    <% if @event.registration_enabled %>
+      <% if current_user && @event.date.future? %>
+          <% if @user_registration %>
+            <%= link_to 'Unregister from Event',
+              registration_path(event_id: @event.id, registration_id: @user_registration),
+              method: :delete,
+              class: "btn btn-danger" %>
+          <% elsif @event.current_capacity < @event.capacity %>
+            <%= link_to 'Register for Event',
+              new_registration_path(event_id: @event.id, user_id: current_user.id),
+              class: "btn btn-success" %>
+          <% else %>
+            <a class="btn btn-danger disabled">Event Full</a>
+          <% end %>
+          <% if current_user&.is_admin? %>
+            <%= link_to 'Guest List', guests_event_path(@event), class: "btn btn-primary" %>
+          <% end %>
+      <% elsif current_user.nil? %>
+         <a class="btn btn-success disabled">Sign in to Register</a>
+      <% end %>
     <% end %>
     <% if current_user&.is_admin? %>
-      <%= link_to 'Guest List', guests_event_path(@event), class: "btn btn-primary" %>
       <%= link_to 'Edit', edit_event_path(@event), class: "btn btn-warning" %>
       <%= link_to 'Delete', event_path(@event),
         method: :delete,

--- a/db/migrate/20190502182741_add_registration_to_events.rb
+++ b/db/migrate/20190502182741_add_registration_to_events.rb
@@ -1,0 +1,5 @@
+class AddRegistrationToEvents < ActiveRecord::Migration[5.1]
+  def change
+    add_column :events, :registration_enabled, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190501193412) do
+ActiveRecord::Schema.define(version: 20190502182741) do
 
   create_table "events", force: :cascade do |t|
     t.string "title"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20190501193412) do
     t.datetime "date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "registration_enabled"
   end
 
   create_table "guests", force: :cascade do |t|


### PR DESCRIPTION
### What are you trying to accomplish?

Make the event registration system optional for events. This will allow us to post external events where registration is not handled by CSS.

### How are you accomplishing it?

- Added `registration_enabled` column to `Event` model
- Added checkbox to toggle registration for event
- Capacity field will only show if checkbox is checked
- Capacity and register/unregister buttons will only show on event page if registration is enabled

### Is there anything reviewers should know?

Nope!

- [x] Is it safe to rollback this change if anything goes wrong?
