### PR TITLE
Added markdown table styling/colors for course list

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,9 +16,30 @@ module ApplicationHelper
 
     }
 
-    renderer = Redcarpet::Render::HTML.new(options)
+    renderer = CustomRender.new(options)
     markdown = Redcarpet::Markdown.new(renderer, extensions)
 
     markdown.render(text).html_safe
+  end
+
+  class CustomRender < Redcarpet::Render::HTML
+    def table(header, body)
+      "<table class=\"table table-bordered\">" \
+        "#{header}#{body}" \
+      "</table>"
+    end
+
+    def table_cell(content, alignment)
+      if content == "Offered"
+        "<td style=\"color:green\">" + content + "</td>"
+      elsif content == "Not Offered"
+        "<td style=\"color:red\">" + content + "</td>"
+      # Had to do this hacky check because of an issue with Redcarpet that has been reported
+      elsif content == "Course Code" || content == "Fall" || content == "Winter" || content == "Summer/Intersession"
+        "<th>" + content + "</th>"
+      else
+        "<td>" + content + "</td>"
+      end
+    end
   end
 end


### PR DESCRIPTION
# **Before:**
![image](https://user-images.githubusercontent.com/1490434/57107479-1b7a3e80-6cfe-11e9-91dc-aed9407e1ec9.png)


# **After:**
![image](https://user-images.githubusercontent.com/1490434/57107486-1fa65c00-6cfe-11e9-87a0-4e05ea3660f6.png)


### What are you trying to accomplish?

Fixes #44.

Add bootstrap styling for markdown tables, and added color formatting specifically for the course offerings table.

### How are you accomplishing it?

Had to overwrite the markdown rendering for tables.

### Is there anything reviewers should know?

Nope.


- [x] Is it safe to rollback this change if anything goes wrong?
