### PR TITLE
Remove Problem of the Week nav item

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,9 +45,6 @@
             <li class="nav-item">
               <a class="nav-link" href="https://github.com/EricPickup/uwindsor-css-hub" target="_blank">Contribute</a>
             </li>
-            <li class="nav-item">
-              <a class="nav-link disabled" href="#">Problem of the Week</a>
-            </li>
           </ul>
           <form class="form-inline my-2 my-lg-0">
             <% if current_user %>


### PR DESCRIPTION
### What are you trying to accomplish?
Remove the Problem of the Week nav item. We do not currently have Problem of the Week up and it is unsure if and when it will be back. Therefore it makes no sense to keep this item until something changes sometime in the future.

### How are you accomplishing it?


### Is there anything reviewers should know?



- [x] Is it safe to rollback this change if anything goes wrong?
