### PR TITLE
New Discord authentication flow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,5 @@ gem 'pry-byebug'
 # Markdown rendering
 gem 'redcarpet'
 gem 'rails-erd'
+gem 'omniauth-discord'
+gem 'rest-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,9 @@ GEM
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
+    omniauth-discord (1.0.0)
+      omniauth
+      omniauth-oauth2
     omniauth-google-oauth2 (0.6.0)
       jwt (>= 2.0)
       omniauth (>= 1.1.1)
@@ -302,6 +305,7 @@ DEPENDENCIES
   jquery-rails
   json
   listen (>= 3.0.5, < 3.2)
+  omniauth-discord
   omniauth-google-oauth2
   pry-byebug
   pry-rails
@@ -309,6 +313,7 @@ DEPENDENCIES
   rails (~> 5.1.6, >= 5.1.6.1)
   rails-erd
   redcarpet
+  rest-client
   rubysl-securerandom
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,7 +20,7 @@
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 50px;
-    margin-top: 100px;
+    margin-top: 20px;
     height: 30px;
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,18 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  helper_method :current_user, :logged_in?
+  helper_method :current_user, :logged_in?, :current_discord_user
 
   skip_before_action :verify_authenticity_token
 
   def current_user
     current_user ||= User.find(session[:user_id]) if session[:user_id]
+  rescue ActiveRecord::RecordNotFound
+    reset_session
+  end
+
+  def current_discord_user
+    current_discord_user ||= DiscordUser.find(session[:discord_user_id]) if session[:discord_user_id]
   rescue ActiveRecord::RecordNotFound
     reset_session
   end

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -1,14 +1,31 @@
 class SessionController < ApplicationController
   def create
-    user = User.find_or_create_by(:email => auth_hash[:info][:email]) do |user|
-      user.email = auth_hash[:info][:email]
-      user.name = auth_hash[:info][:name]
-      user.hd = auth_hash[:extra][:raw_info][:hd]
+    provider = auth_hash[:provider]
+    if provider == "google_oauth2"
+      user = User.find_or_create_by(:email => auth_hash[:info][:email]) do |user|
+        user.email = auth_hash[:info][:email]
+        user.name = auth_hash[:info][:name]
+        user.hd = auth_hash[:extra][:raw_info][:hd]
+      end
+
+      session[:user_id] = user.id
+      redirect_to request.env["omniauth.origin"]
+    elsif provider == "discord"
+      discord_user = DiscordUser.find_or_create_by(discord_uid: auth_hash[:uid])
+      if current_user
+        if current_user.discord_user.nil? || !current_user.discord_user.verified? || current_user.discord_user == discord_user
+          discord_user.update(verified: true)
+          current_user.update(discord_user: discord_user)
+          session[:discord_user_id] = discord_user.id
+          add_user_to_discord_guild(current_user, current_user.discord_user, auth_hash[:credentials][:token])
+          redirect_to :discord_path, flash: { success: "You've successfully linked your Discord account and have been added to the UWindsor CSS Discord server!" }
+        else
+          redirect_to :discord_path, flash: { error: "You've already linked another Discord account to this email!" }
+        end
+      else
+        redirect_to :discord_path, flash: { error: "Authorize/sign-in with UWindsor before signing into Discord" }
+      end
     end
-
-    session[:user_id] = user.id
-
-    redirect_to request.env["omniauth.origin"]
   end
 
   def destroy
@@ -17,9 +34,23 @@ class SessionController < ApplicationController
     redirect_to request.referrer
   end
 
+  def destroy_discord
+    session[:discord_user_id] = nil
+
+    redirect_to request.referrer
+  end
+
   private
 
   def auth_hash
     request.env["omniauth.auth"]
+  end
+
+  def add_user_to_discord_guild(user, discord_user, access_token)
+    RestClient.put(
+      "https://discordapp.com/api/guilds/#{ENV['DISCORD_GUILD_ID']}/members/#{discord_user.discord_uid}",
+      { access_token: access_token, nick: user.name }.to_json,
+      { content_type: :json, Authorization: "Bot #{ENV['DISCORD_BOT_TOKEN']}" }
+    )
   end
 end

--- a/app/models/discord_user.rb
+++ b/app/models/discord_user.rb
@@ -1,0 +1,3 @@
+class DiscordUser < ApplicationRecord
+  belongs_to :user, optional: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_many :registrations
   has_many :events, through: :registrations
   has_one :discord_verification
+  has_one :discord_user
 
   def is_admin?
     self.role == "admin"

--- a/app/views/pages/discord.html.erb
+++ b/app/views/pages/discord.html.erb
@@ -9,9 +9,37 @@
 
 <center>
   <br>
-  Create a Discord account at <a href="https://discordapp.com/register">https://discordapp.com/register</a>
+  <p><a href="https://discordapp.com" target="_blank">Discord</a> is a free VoIP application that specializes in text, image, video, and audio communication between users in chat channels.</p>
+
+  <p>The Computer Science Society created a private Discord server in 2018 to connect Computer Science students and enable discussions for courses, co-op/internships, general chat and more. There are <i>hundreds</i> of students registered in the server.</p>
+
+  <p>All users in the Discord server are linked to their UWindsor email addresses to verify identity and to restrict the server to UWindsor students only.</p>
+
+  <p>Follow the steps below to join.</p>
+  <br>
+  <% if current_user&.discord_user&.verified? %>
+    <b>A Discord user has already been linked to this UWindsor account.<br>You may proceed with the steps below if you've left the server and wish to re-join.</b>
+    <br><br>
+  <% end %>
+
+  <% if current_user %>
+    <%= link_to "✓ Step 1: Authorized with UWindsor", :google_auth, class: "btn btn-primary" %>
+  <% else %>
+    <%= link_to "Step 1: Authorize with UWindsor", :google_auth, class: "btn btn-outline-primary" %>
+  <% end %>
   <br><br>
-  If you already have a Discord account, simply join with the button below!
-  <br><br>
-  <%= link_to "Join Discord", "https://discord.gg/MzYMkcj", class: "btn btn-primary", target: "_blank" %>
+  <% if current_discord_user %>
+    <%= link_to "✓ Step 2: Authorized with Discord", :discord_auth, class: "btn btn-primary" %>
+  <% else %>
+    <% if current_user %>
+      <%= link_to "Step 2: Authorize with Discord", :discord_auth, class: "btn btn-outline-primary" %>
+    <% else %>
+      <%= link_to "Step 2: Authorize with Discord", :discord_auth, class: "btn btn-outline-primary disabled" %>
+    <% end %>
+  <% end %>
+  <% if current_discord_user %>
+    <br><br><br>
+    <%= link_to "Sign out of Discord", :discord_logout, class: "btn btn-outline-danger" %>
+  <% end %>
+
 </center>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,7 @@ module UWindsorCssHub
     # -- all .rb files in that directory are automatically loaded.
     config.middleware.use OmniAuth::Builder do
       provider :google_oauth2, ENV['GOOGLE_CLIENT'], ENV['GOOGLE_SECRET'], { hd: 'uwindsor.ca', prompt: 'select_account' }
+      provider :discord, ENV['DISCORD_CLIENT_ID'], ENV['DISCORD_CLIENT_SECRET'], scope: 'guilds.join', permissions: 0x00000001 + 0x08000000
     end
   end
 end

--- a/config/initializers/discord_bot.rb
+++ b/config/initializers/discord_bot.rb
@@ -5,8 +5,8 @@ require 'fuzzystringmatch'
 
 class Main
   ::Bot = Discordrb::Commands::CommandBot.new(
-    token: ENV['DISCORD_API_TOKEN'],
-    client_id: ENV['DISCORD_API_CLIENT_ID'],
+    token: ENV['DISCORD_BOT_TOKEN'],
+    client_id: ENV['DISCORD_CLIENT_ID'],
     prefix: '~',
     help_command: false,
   )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,10 @@ Rails.application.routes.draw do
   get 'events/index'
 
   get 'session/destroy', :as => 'logout'
+  get 'session/destroy_discord', :as => 'discord_logout'
 
   get 'auth/google_oauth2', :as => 'google_auth'
+  get 'auth/discord', :as => 'discord_auth'
   match 'auth/:provider/callback' => 'session#create', :via => [:post, :get]
 
    # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html	  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/db/migrate/20190507183919_create_discord_users.rb
+++ b/db/migrate/20190507183919_create_discord_users.rb
@@ -1,0 +1,11 @@
+class CreateDiscordUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :discord_users do |t|
+      t.integer :discord_uid, limit: 8
+      t.boolean :verified
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190507193411_add_api_token_to_discord_users.rb
+++ b/db/migrate/20190507193411_add_api_token_to_discord_users.rb
@@ -1,0 +1,5 @@
+class AddApiTokenToDiscordUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :discord_users, :api_token, :string
+  end
+end

--- a/db/migrate/20190507211107_remove_api_token_from_discord_users.rb
+++ b/db/migrate/20190507211107_remove_api_token_from_discord_users.rb
@@ -1,0 +1,5 @@
+class RemoveApiTokenFromDiscordUsers < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :discord_users, :api_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190507173609) do
+ActiveRecord::Schema.define(version: 20190507211107) do
+
+  create_table "discord_users", force: :cascade do |t|
+    t.integer "discord_uid", limit: 8
+    t.boolean "verified"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_discord_users_on_user_id"
+  end
 
   create_table "discord_verifications", id: :string, limit: 8, force: :cascade do |t|
     t.integer "discord_user", limit: 8

--- a/test/fixtures/discord_users.yml
+++ b/test/fixtures/discord_users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  discord_uid: 1
+  verified: false
+  user: one
+
+two:
+  discord_uid: 1
+  verified: false
+  user: two

--- a/test/models/discord_user_test.rb
+++ b/test/models/discord_user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class DiscordUserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Instead of using bots/commands combined with the web app to verify Discord users, use OAuth with UWindsor AND Discord to verify users in a two-step process.

Users simply log into UWindsor, log into Discord, and they will be added to the Discord server automatically through the API.

### How are you accomplishing it?

### Is there anything reviewers should know?



- [x] Is it safe to rollback this change if anything goes wrong?
