### PR TITLE
Add service to send messages to Discord

### DIFF
--- a/app/services/discord_message_sender_service.rb
+++ b/app/services/discord_message_sender_service.rb
@@ -1,0 +1,18 @@
+class DiscordMessageSenderService
+  DISCORD_API_ENDPOINT = "https://discordapp.com/api"
+
+  def initialize(channel_id, content, options = {})
+    @channel_id = channel_id
+    @content = content
+    @options = options
+  end
+
+  def send_message!
+    options.merge!(content: @content)
+    RestClient.post(
+      "#{DISCORD_API_ENDPOINT}/channels/#{@channel_id}/messages",
+      @options.to_json,
+      { content_type: :json, Authorization: "Bot #{ENV['DISCORD_BOT_TOKEN']}" }
+    )
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?
Add a service that will allow us to send messages to Discord channels on behalf of the bot.

### How are you accomplishing it?
Straight forward

### Is there anything reviewers should know?
Options exist here: https://discordapp.com/developers/docs/resources/channel#create-message


- [x] Is it safe to rollback this change if anything goes wrong?
